### PR TITLE
Update calico.yaml

### DIFF
--- a/chart/templates/calico.yaml
+++ b/chart/templates/calico.yaml
@@ -28,4 +28,6 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 1m
+    syncOptions:
+      - Replace=true
 {{- end -}}


### PR DESCRIPTION
allowing argo to "replace" addon, due to the annotation size being exceeded when applying the Installation CRD